### PR TITLE
Patch 5

### DIFF
--- a/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
+++ b/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
@@ -55,9 +55,9 @@ abstract class ArticleAbstract extends ResourceAbstract
     public function formatSingleArticle($article)
     {
         $data = new \stdClass();
-        $html = utf8_decode($article->Content);
-        $crawler = new Crawler($html);
-
+        $crawler = new Crawler();
+        $crawler->addHtmlContent($article->Content);
+        
         // Basic article data
         $data->id = $article->ArticleID;
         $data->title = html_entity_decode($article->ArticleTitle, ENT_NOQUOTES, 'UTF-8');

--- a/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
+++ b/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
@@ -57,7 +57,7 @@ abstract class ArticleAbstract extends ResourceAbstract
         $data = new \stdClass();
         $crawler = new Crawler();
         $crawler->addHtmlContent($article->Content);
-        
+
         // Basic article data
         $data->id = $article->ArticleID;
         $data->title = html_entity_decode($article->ArticleTitle, ENT_NOQUOTES, 'UTF-8');


### PR DESCRIPTION
Fixing encoding issues - avoid text gabling

during the import some of the text was garbled. For example, the import of this article https://www.borger.dk/arbejde-dagpenge-ferie/Dagpenge-kontanthjaelp-og-sygedagpenge/Kontanthjaelp/Kontanthjaelp-30-eller-derover, and more specifically microarticle "Jobparat – hvad skal jeg?", resulted in "Jobparat ? hvad skal jeg?" 
